### PR TITLE
swap: define Darwin (b|l)e16toh equivalents

### DIFF
--- a/include/platform/swap.h
+++ b/include/platform/swap.h
@@ -8,6 +8,10 @@
 #	include <endian.h>	// be??toh
 #elif HAVE_SYS_ENDIAN_H
 #	include <sys/endian.h>	// see endian.h (but for BSD)
+#elif defined(__APPLE__)
+#   include <libkern/OSByteOrder.h>
+#   define be16toh(x) OSSwapBigToHostInt16(x)
+#   define le16toh(x) OSSwapLittleToHostInt16(x)
 #else
 
 // Implement a BSD-like interface as a fallback


### PR DESCRIPTION
Since these functions are always available on Darwin, I figured it wasn't necessarily worth explicitly checking for them in cmake and just added an `#ifdef __APPLE__`.
