### PR TITLE
Fix FreeBSD build

### DIFF
--- a/cmake/Modules/platform.cmake
+++ b/cmake/Modules/platform.cmake
@@ -40,19 +40,23 @@ endmacro()
 
 macro(clock_check)
 	if(HAVE_POSIX)
-		# XXX hack to make this check work
-		set(CMAKE_REQUIRED_DEFINITIONS -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_VERSION=700)
 		check_symbol_exists(clock_gettime time.h HAVE_CLOCK_GETTIME)
 
-		if(HAVE_CLOCK_GETTIME)
-			# Needed to see it
-			add_definitions(-D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_VERSION=700)
-		else()
-			# OS X check
-			check_include_files("mach/mach.h;mach/clock.h" HAVE_MACH_CLOCK_H)
+		if(NOT(HAVE_CLOCK_GETTIME))
+			# XXX hack to make this check work
+			set(CMAKE_REQUIRED_DEFINITIONS -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_VERSION=700)
+			check_symbol_exists(clock_gettime time.h HAVE_CLOCK_GETTIME)
+			if(HAVE_CLOCK_GETTIME)
+				# Needed to see it
+				add_definitions(-D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L -D_XOPEN_VERSION=700)
+			else()
+				# OS X check
+				check_include_files("mach/mach.h;mach/clock.h" HAVE_MACH_CLOCK_H)
+			endif()
 		endif()
 
 		check_symbol_exists(nanosleep time.h HAVE_NANOSLEEP)
+		check_symbol_exists(clock_nanosleep time.h HAVE_CLOCK_NANOSLEEP)
 	endif()
 endmacro()
 

--- a/include/platform/sleep_posix.h
+++ b/include/platform/sleep_posix.h
@@ -16,7 +16,7 @@ static inline void sleep_nsec(uint64_t nsec)
 	ts.tv_sec = nsec / NSEC_SEC;
 	ts.tv_nsec = nsec % NSEC_SEC;
 
-#ifndef HAVE_CLOCK_GETTIME
+#ifndef HAVE_CLOCK_NANOSLEEP
 	if(nanosleep(&ts, &ret))
 #else
 	if(clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, &ret))

--- a/include/platform/swap.h
+++ b/include/platform/swap.h
@@ -6,7 +6,7 @@
 // Check for BSD or Linux-style interface
 #ifdef HAVE_ENDIAN_H
 #	include <endian.h>	// be??toh
-#elif HAVE_SYS_ENDIAN_H
+#elif defined(HAVE_SYS_ENDIAN_H)
 #	include <sys/endian.h>	// see endian.h (but for BSD)
 #elif defined(__APPLE__)
 #	include <libkern/OSByteOrder.h>


### PR DESCRIPTION
Mostly pertaining to nanosleep and the fact that FreeBSD doesn't have clock_nanosleep, as well as the fact that if you define all the crap in those checks without checking if it exists first it breaks all the BSD extentions and the compiler shits itself on mmap.c.
